### PR TITLE
TestFlight Notification

### DIFF
--- a/lib/beta_builder/deployment_strategies/testflight.rb
+++ b/lib/beta_builder/deployment_strategies/testflight.rb
@@ -23,7 +23,7 @@ module BetaBuilder
           :file               => File.new(@configuration.ipa_path, 'rb'),
           :notes              => get_notes,
           :distribution_lists => (@configuration.distribution_lists || []).join(","),
-          :notify             => false
+          :notify             => @configuration.notify || false
         }
         puts "Uploading build to TestFlight..."
         


### PR DESCRIPTION
This small patch let's the user set if they want to automatically notify their distribution list when they deploy to TestFlight. If omitted the default is false.
