### PR TITLE
Fix for XCode 4 workspaces

### DIFF
--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -21,7 +21,11 @@ module BetaBuilder
     
     class Configuration < OpenStruct
       def build_arguments
-        "-target '#{target}' -configuration '#{configuration}' -sdk iphoneos"
+        if workspace
+          "-workspace '#{workspace}' -scheme '#{target}' -configuration '#{configuration}' -sdk iphoneos"
+        else
+          "-target '#{target}' -configuration '#{configuration}' -sdk iphoneos"
+        end
       end
       
       def app_name


### PR DESCRIPTION
So I had to make 1 small change to get this to work with betabuilder. If "workspace" is set in config it will use the alternate build arguments... it would be nice if betabuilder could find the DerivedData folder the workspace is using, but at the moment I can set it by hand with the build_dir arg. Sending a pull request separately... Thanks Luke!
