### PR TITLE
Configurable xcodebuild path

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## 0.4.2
+* Support configurable path to xcodebuild executable
+
 ## 0.4
 * If the user has set the EDITOR environment variable, use it to obtain the TestFlight release notes.
 * Bugfix: TestFlight API now returns a 201 Created response when successful.

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ spec = Gem::Specification.new do |s|
 
   # Change these as appropriate
   s.name              = "betabuilder"
-  s.version           = "0.4.1"
+  s.version           = "0.4.2"
   s.summary           = "A set of Rake tasks and utilities for managing iOS ad-hoc builds"
   s.author            = "Luke Redpath"
   s.email             = "luke@lukeredpath.co.uk"

--- a/betabuilder.gemspec
+++ b/betabuilder.gemspec
@@ -2,18 +2,18 @@
 
 Gem::Specification.new do |s|
   s.name = %q{betabuilder}
-  s.version = "0.4.1"
+  s.version = "0.4.2"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Luke Redpath"]
-  s.date = %q{2011-02-11}
+  s.date = %q{2011-06-17}
   s.email = %q{luke@lukeredpath.co.uk}
   s.extra_rdoc_files = ["README.md", "LICENSE", "CHANGES.md"]
   s.files = ["CHANGES.md", "LICENSE", "README.md", "lib/beta_builder/archived_build.rb", "lib/beta_builder/deployment_strategies/testflight.rb", "lib/beta_builder/deployment_strategies/web.rb", "lib/beta_builder/deployment_strategies.rb", "lib/beta_builder.rb", "lib/betabuilder.rb"]
   s.homepage = %q{http://github.com/lukeredpath/betabuilder}
   s.rdoc_options = ["--main", "README.md"]
   s.require_paths = ["lib"]
-  s.rubygems_version = %q{1.4.1}
+  s.rubygems_version = %q{1.7.2}
   s.summary = %q{A set of Rake tasks and utilities for managing iOS ad-hoc builds}
 
   if s.respond_to? :specification_version then

--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -12,7 +12,8 @@ module BetaBuilder
         :configuration => "Adhoc",
         :build_dir => "build",
         :auto_archive => false,
-        :archive_path  => File.expand_path("~/Library/Application Support/Developer/Shared/Archived Applications")
+        :archive_path  => File.expand_path("~/Library/Application Support/Developer/Shared/Archived Applications"),
+        :xcodebuild_executable => "xcodebuild"
       )
       @namespace = namespace
       yield @configuration if block_given?
@@ -64,11 +65,11 @@ module BetaBuilder
       namespace(@namespace) do
         desc "Build the beta release of the app"
         task :build => :clean do
-          system("xcodebuild #{@configuration.build_arguments} build")
+          system("#{@configuration.xcodebuild_executable} #{@configuration.build_arguments} build")
         end
         
         task :clean do
-          system("xcodebuild #{@configuration.build_arguments} clean")
+          system("#{@configuration.xcodebuild_executable} #{@configuration.build_arguments} clean")
         end
         
         desc "Package the beta release as an IPA file"


### PR DESCRIPTION
This will help those that have non-released beta dev tools and do not want to build their application using a beta version of xcodebuild.
