### PR TITLE
Xcode 4-style archives

### DIFF
--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -14,7 +14,8 @@ module BetaBuilder
         :auto_archive => false,
         :archive_path  => File.expand_path("~/Library/Application Support/Developer/Shared/Archived Applications"),
         :xcodebuild_path => "xcodebuild",
-        :project_file_path => nil
+        :project_file_path => nil,
+        :xcode4_archive_mode => false
       )
       @namespace = namespace
       yield @configuration if block_given?

--- a/lib/beta_builder/archived_build.rb
+++ b/lib/beta_builder/archived_build.rb
@@ -9,7 +9,14 @@ module BetaBuilder
     end
     
     def save_to(path)
-      archive_path = File.join(path, "#{@uuid}.apparchive")
+      if @configuration.xcode4_archive_mode
+        date_path = File.join(path, "#{Time.now.strftime('%Y-%m-%d')}")
+        FileUtils.mkdir_p(date_path)
+        archive_path = File.join(date_path, "#{@configuration.target}.xcarchive")
+      else
+        archive_path = File.join(path, "#{@uuid}.apparchive")
+      end
+      
       FileUtils.mkdir(archive_path)
       FileUtils.cp_r(@configuration.built_app_path, archive_path)
       FileUtils.cp_r(@configuration.built_app_dsym_path, archive_path)


### PR DESCRIPTION
I added a mode to generate Xcode 4 style archives.  Not sure how to best switch the paths to the Xcode 4 archive folder, so I'm just providing it via config override in my project.  Let me know if you'd rather this be done automatically for the user (i.e. - setting xcod4_archive_mode also sets the path to the common location).
