### PR TITLE
Widens the search for the derived data folder in the build output

### DIFF
--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -48,6 +48,7 @@ module BetaBuilder
       end
       
       def app_file_name
+        raise ArgumentError, "app_name or target must be set in the BetaBuilder configuration block" if app_name.nil? && target.nil?
         if app_name
           "#{app_name}.app"
         else
@@ -75,8 +76,8 @@ module BetaBuilder
         output = File.read("build.output")
         
         # yes, this is truly horrible, but unless somebody else can find a better way...
-        reference = output.split("\n").grep(/Xcode\/DerivedData\/#{scheme}-(.*)/).first.split(" ").last
-        derived_data_directory = reference.split("/Build/Products").first
+        reference = output.split("\n").grep(/Xcode\/DerivedData\/(.*)-(.*)/).first.split(" ").last
+        derived_data_directory = reference.split("/Build/Products/").first
         "#{derived_data_directory}/Build/Products/"
       end
       


### PR DESCRIPTION
Correct an issue where the first derived path found contains a file, leading to a double forward slash in the calculated path.
Raise an ArgumentError if the configuration is missing target AND app_name, which would lead to a bad path.
