### PR TITLE
Some improvements (supply arch flag, dry run & verbose config, lazy fetch release notes)

### DIFF
--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -18,6 +18,7 @@ module BetaBuilder
         :workspace_path => nil,
         :scheme => nil,
         :app_name => nil,
+        :arch => nil,
         :xcode4_archive_mode => false,
         :skip_clean => false,
         :verbose => false,
@@ -27,28 +28,32 @@ module BetaBuilder
       yield @configuration if block_given?
       define
     end
-        
+
     def xcodebuild(*args)
       # we're using tee as we still want to see our build output on screen
       system("#{@configuration.xcodebuild_path} #{args.join(" ")} | tee build.output")
     end
-    
+
     class Configuration < OpenStruct
       def release_notes_text
         return release_notes.call if release_notes.is_a? Proc
         release_notes
       end
       def build_arguments
+        args = ""
         if workspace_path
           raise "A scheme is required if building from a workspace" unless scheme
-          "-workspace '#{workspace_path}' -scheme '#{scheme}' -configuration '#{configuration}'"
+          args << "-workspace '#{workspace_path}' -scheme '#{scheme}' -configuration '#{configuration}'"
         else
           args = "-target '#{target}' -configuration '#{configuration}' -sdk iphoneos"
           args << " -project #{project_file_path}" if project_file_path
-          args
         end
+
+        args << " -arch \"#{arch}\"" unless arch.nil?
+
+        args
       end
-      
+
       def archive_name
         app_name || target
       end

--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -27,13 +27,17 @@ module BetaBuilder
       yield @configuration if block_given?
       define
     end
-    
+        
     def xcodebuild(*args)
       # we're using tee as we still want to see our build output on screen
       system("#{@configuration.xcodebuild_path} #{args.join(" ")} | tee build.output")
     end
     
     class Configuration < OpenStruct
+      def release_notes_text
+        return release_notes.call if release_notes.is_a? Proc
+        release_notes
+      end
       def build_arguments
         if workspace_path
           raise "A scheme is required if building from a workspace" unless scheme

--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -19,7 +19,9 @@ module BetaBuilder
         :scheme => nil,
         :app_name => nil,
         :xcode4_archive_mode => false,
-        :skip_clean => false
+        :skip_clean => false,
+        :verbose => false,
+        :dry_run => false
       )
       @namespace = namespace
       yield @configuration if block_given?

--- a/lib/beta_builder/archived_build.rb
+++ b/lib/beta_builder/archived_build.rb
@@ -70,11 +70,12 @@ module BetaBuilder
     private
     
     def write_plist_to(path)
+      version = metadata["CFBundleShortVersionString"] || metadata["CFBundleVersion"]
       plist = {
         "ApplicationProperties" => {
           "ApplicationPath"             => File.join("Applications", @configuration.app_file_name),
           "CFBundleIdentifier"          => metadata["CFBundleIdentifier"], 
-          "CFBundleShortVersionString"  => metadata["CFBundleShortVersionString"], 
+          "CFBundleShortVersionString"  => version, 
           "IconPaths"                   => metadata["CFBundleIconFiles"].map { |file| File.join("Applications", @configuration.app_file_name, file) }
         }, 
         "ArchiveVersion" => 1.0, 

--- a/lib/beta_builder/archived_build.rb
+++ b/lib/beta_builder/archived_build.rb
@@ -79,7 +79,7 @@ module BetaBuilder
           "IconPaths"                   => metadata["CFBundleIconFiles"].map { |file| File.join("Applications", @configuration.app_file_name, file) }
         }, 
         "ArchiveVersion" => 1.0, 
-        "Comment"        => @configuration.release_notes, 
+        "Comment"        => @configuration.release_notes_text,
         "CreationDate"   => Time.now, 
         "Name"           => @configuration.archive_name, 
         "SchemeName"     => @configuration.scheme

--- a/lib/beta_builder/deployment_strategies/testflight.rb
+++ b/lib/beta_builder/deployment_strategies/testflight.rb
@@ -11,7 +11,7 @@ module BetaBuilder
       def extended_configuration_for_strategy
         proc do
           def generate_release_notes(&block)
-            self.release_notes = yield if block_given?
+            self.release_notes = block if block
           end
         end
       end
@@ -53,7 +53,8 @@ module BetaBuilder
       private
       
       def get_notes
-        @configuration.release_notes || get_notes_using_editor || get_notes_using_prompt
+        notes = @configuration.release_notes_text
+        notes || get_notes_using_editor || get_notes_using_prompt
       end
       
       def get_notes_using_editor

--- a/lib/beta_builder/deployment_strategies/testflight.rb
+++ b/lib/beta_builder/deployment_strategies/testflight.rb
@@ -17,15 +17,25 @@ module BetaBuilder
       end
       
       def deploy
+        release_notes = get_notes
         payload = {
           :api_token          => @configuration.api_token,
           :team_token         => @configuration.team_token,
           :file               => File.new(@configuration.ipa_path, 'rb'),
-          :notes              => get_notes,
+          :notes              => release_notes,
           :distribution_lists => (@configuration.distribution_lists || []).join(","),
           :notify             => @configuration.notify || false
         }
         puts "Uploading build to TestFlight..."
+        if @configuration.verbose
+          puts "ipa path: #{@configuration.ipa_path}"
+          puts "release notes: #{release_notes}"
+        end
+        
+        if @configuration.dry_run 
+          puts '** Dry Run - No action here! **'
+          return
+        end
         
         begin
           response = RestClient.post(ENDPOINT, payload, :accept => :json)


### PR DESCRIPTION
I've made a few tweaks here:
- supplying the arch flag (Xcode 4's command line build was always building for armv7, despite my project allowing both armv6 and 7).  Can now supply the arch flag with:

``` ruby
config.arch = "armv6 armv7"
```
- Dry run / verbose

It's handy to see what's going on without actually publishing 20 builds to test flight :).  These are defaulted to false, but can easily be turned on:

``` ruby
config.dry_run = true
config.verbose = true
```
- Lazy generate release notes

The way release notes were captured, it was done at definition time, not at call time, which prevented users from being able to utilize other Rake tasks to help generate these notes.  For me, I was using a combination of git logs in a rake task.  Now the release notes captures the block itself for the string and doesn't call the block until the last possible moment.
