### PR TITLE
I've fixed a bug with detecting derived build_dir if there is a space in the app name

### DIFF
--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -87,7 +87,12 @@ module BetaBuilder
         output = File.read("build.output")
         
         # yes, this is truly horrible, but unless somebody else can find a better way...
-        reference = output.split("\n").grep(/^Validate(.*)\/Xcode\/DerivedData\/(.*)-(.*)/).first.split(" ").last
+        found = output.split("\n").grep(/^Validate(.*)\/Xcode\/DerivedData\/(.*)-(.*)/).first
+        if found && found =~ /Validate \"(.*)\"/
+            reference = $1 
+        else 
+            raise "Cannot parse build_dir from build output."
+        end        
         derived_data_directory = reference.split("/Build/Products/").first
         "#{derived_data_directory}/Build/Products/"
       end


### PR DESCRIPTION
Hey Luke,

There was a bug in the detection logic - it's pretty trivial to fix. I had tried the other approach (from drodriguez pull request) but this does not seem to work with Xcode 4.2 GM. Hope this is useful

Chris
