### PR TITLE
Fix for archive task not being found when using namespaces

### DIFF
--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -149,7 +149,15 @@ module BetaBuilder
           FileUtils.mkdir('pkg/dist')
           FileUtils.mv("pkg/#{@configuration.ipa_name}", "pkg/dist")
         end
-        
+
+        desc "Build and archive the app"
+        task :archive => :build do
+          puts "Archiving build..."
+          archive = BetaBuilder.archive(@configuration)
+          output_path = archive.save_to(@configuration.archive_path)
+          puts "Archive saved to #{output_path}."
+        end
+
         if @configuration.deployment_strategy
           desc "Prepare your app for deployment"
           task :prepare => :package do
@@ -168,13 +176,7 @@ module BetaBuilder
           end
         end
         
-        desc "Build and archive the app"
-        task :archive => :build do
-          puts "Archiving build..."
-          archive = BetaBuilder.archive(@configuration)
-          output_path = archive.save_to(@configuration.archive_path)
-          puts "Archive saved to #{output_path}."
-        end
+
       end
     end
   end


### PR DESCRIPTION
deploy and prepare tasks would give the error:

```
Don't know how to build task 'beta:archive'
```

when used in conjunction with namespaces. Moving the archive task above
the deployment_strategy section seems to fix this.
