### PR TITLE
fixed require of CFPropertyList

### DIFF
--- a/lib/beta_builder/archived_build.rb
+++ b/lib/beta_builder/archived_build.rb
@@ -1,6 +1,6 @@
 require 'uuid'
 require 'fileutils'
-require 'CFPropertyList'
+require 'cfpropertylist'
 
 module BetaBuilder
   def self.archive(configuration)


### PR DESCRIPTION
Hi,
I could not include betabuilder cause it could not load CFPropertyList. I always got this error:

no such file to load -- CFPropertyList
.../gems/betabuilder-0.7.4.1/lib/beta_builder/archived_build.rb:3:in `require'

Writing the require lowercase fixed it.
