### PR TITLE
Allow custom ports in scp commands + other minor fixes

### DIFF
--- a/lib/beta_builder/deployment_strategies.rb
+++ b/lib/beta_builder/deployment_strategies.rb
@@ -34,6 +34,6 @@ module BetaBuilder
   end
 end
 
-require 'beta_builder/deployment_strategies/web'
-require 'beta_builder/deployment_strategies/testflight'
+require File.dirname(__FILE__) + '/deployment_strategies/web'
+require File.dirname(__FILE__) + '/deployment_strategies/testflight'
 

--- a/lib/beta_builder/deployment_strategies/web.rb
+++ b/lib/beta_builder/deployment_strategies/web.rb
@@ -16,7 +16,7 @@ module BetaBuilder
           end
         end
       end
-      
+
       def prepare
         plist = CFPropertyList::List.new(:file => "pkg/Payload/#{@configuration.app_name}/Info.plist")
         plist_data = CFPropertyList.native_types(plist.value)
@@ -82,9 +82,20 @@ module BetaBuilder
           }
         end
       end
-      
+
       def deploy
-        system("scp pkg/dist/* #{@configuration.remote_host}:#{@configuration.remote_installation_path}")
+        cmd = []
+
+        cmd.push "scp"
+
+        if @configuration.remote_port
+          cmd.push "-P #{@configuration.remote_port}"
+        end
+
+        cmd.push "pkg/dist/*"
+        cmd.push "#{@configuration.remote_host}:#{@configuration.remote_installation_path}"
+
+        system(cmd.join(" "))
       end
     end
   end

--- a/lib/beta_builder/deployment_strategies/web.rb
+++ b/lib/beta_builder/deployment_strategies/web.rb
@@ -18,7 +18,7 @@ module BetaBuilder
       end
 
       def prepare
-        plist = CFPropertyList::List.new(:file => "pkg/Payload/#{@configuration.app_name}/Info.plist")
+        plist = CFPropertyList::List.new(:file => "pkg/Payload/#{@configuration.app_file_name}/Info.plist")
         plist_data = CFPropertyList.native_types(plist.value)
         File.open("pkg/dist/manifest.plist", "w") do |io|
           io << %{
@@ -95,7 +95,10 @@ module BetaBuilder
         cmd.push "pkg/dist/*"
         cmd.push "#{@configuration.remote_host}:#{@configuration.remote_installation_path}"
 
-        system(cmd.join(" "))
+        cmd = cmd.join(" ")
+
+        puts "* Running `#{cmd}`"
+        system(cmd)
       end
     end
   end

--- a/lib/betabuilder.rb
+++ b/lib/betabuilder.rb
@@ -1,1 +1,1 @@
-require 'beta_builder'
+require File.dirname(__FILE__) + '/beta_builder'


### PR DESCRIPTION
- Fix #35 - allows custom port in scp command
- Use app_file_name instead of app_name so that scp deploy strategy respects app_name
- Add output for scp command
- Use relative requires so that the project can be used outside of rubygems
