### PR TITLE
Fail Rake task if build fails

### DIFF
--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -32,7 +32,7 @@ module BetaBuilder
 
     def xcodebuild(*args)
       # we're using tee as we still want to see our build output on screen
-      system("#{@configuration.xcodebuild_path} #{args.join(" ")} | tee build.output")
+      system("#{@configuration.xcodebuild_path} #{args.join(" ")} 2>&1 | tee build.output")
     end
 
     class Configuration < OpenStruct
@@ -118,6 +118,7 @@ module BetaBuilder
         desc "Build the beta release of the app"
         task :build => :clean do
           xcodebuild @configuration.build_arguments, "build"
+          raise "** BUILD FAILED **" if BuildOutputParser.new(File.read("build.output")).failed?
         end
         
         task :clean do

--- a/lib/beta_builder/build_output_parser.rb
+++ b/lib/beta_builder/build_output_parser.rb
@@ -16,6 +16,10 @@ module BetaBuilder
       derived_data_directory = reference.split("/Build/Products/").first
       "#{derived_data_directory}/Build/Products/"
     end
+
+    def failed?
+      @output.split("\n").any? {|line| line.include? "** BUILD FAILED **"}
+    end
   end
 end
 


### PR DESCRIPTION
If xcodebuild fails, it doesn't necessarily return a non-zero exit code. We have to go into the output and see if it emitted a *\* BUILD FAILED *\* line to determine that. It's useful to halt Rake if we have other tasks that depend on the build succeeding.
