### PR TITLE
Fixing CFBundleIconFiles reference for newer projects

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,11 +15,11 @@ spec = Gem::Specification.new do |s|
 
   # Change these as appropriate
   s.name              = "betabuilder"
-  s.version           = "0.7.4.1"
+  s.version           = "0.7.5"
   s.summary           = "A set of Rake tasks and utilities for managing iOS ad-hoc builds"
-  s.author            = "Luke Redpath"
-  s.email             = "luke@lukeredpath.co.uk"
-  s.homepage          = "http://github.com/lukeredpath/betabuilder"
+  s.authors           = ["Luke Redpath", "Nick Peelman"]
+  s.email             = ["luke@lukeredpath.co.uk", "nick@peelman.us"]
+  s.homepage          = "http://github.com/peelman/betabuilder"
 
   s.has_rdoc          = false
   s.extra_rdoc_files  = %w(README.md LICENSE CHANGES.md)

--- a/betabuilder.gemspec
+++ b/betabuilder.gemspec
@@ -1,20 +1,20 @@
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |s|
-  s.name = "betabuilder"
-  s.version = "0.7.4.1"
-
+  s.name              = "betabuilder"
+  s.version           = "0.7.5"
+  s.summary           = "A set of Rake tasks and utilities for managing iOS ad-hoc builds"
+  s.authors           = ["Luke Redpath", "Nick Peelman"]
+  s.email             = ["luke@lukeredpath.co.uk", "nick@peelman.us"]
+  s.homepage          = "http://github.com/peelman/betabuilder"
+  
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = ["Luke Redpath"]
-  s.date = "2011-11-16"
-  s.email = "luke@lukeredpath.co.uk"
+  s.date = "2012-04-25"
   s.extra_rdoc_files = ["README.md", "LICENSE", "CHANGES.md"]
   s.files = ["CHANGES.md", "LICENSE", "README.md", "lib/beta_builder/archived_build.rb", "lib/beta_builder/build_output_parser.rb", "lib/beta_builder/deployment_strategies/testflight.rb", "lib/beta_builder/deployment_strategies/web.rb", "lib/beta_builder/deployment_strategies.rb", "lib/beta_builder.rb", "lib/betabuilder.rb"]
-  s.homepage = "http://github.com/lukeredpath/betabuilder"
   s.rdoc_options = ["--main", "README.md"]
   s.require_paths = ["lib"]
   s.rubygems_version = "1.8.11"
-  s.summary = "A set of Rake tasks and utilities for managing iOS ad-hoc builds"
 
   if s.respond_to? :specification_version then
     s.specification_version = 3

--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -147,7 +147,7 @@ module BetaBuilder
 #            system("zip -r '#{@configuration.ipa_name}' Payload")
 #          end
           
-          system("/usr/bin/xcrun -sdk iphoneos PackageApplication -v '#{@configuration.built_app_path}' -o '/tmp/#{@configuration.ipa_name}' --sign '#{@config.signing_identity}' --embed #{@configuration.provisioning_profile}")
+          system("/usr/bin/xcrun -sdk iphoneos PackageApplication -v '#{@configuration.built_app_path}' -o '/tmp/#{@configuration.ipa_name}' --sign '#{@configuration.signing_identity}' --embed #{@configuration.provisioning_profile}")
 
           FileUtils.mkdir('pkg/dist')
           FileUtils.mv("/tmp/#{@configuration.ipa_name}", "pkg/dist")

--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -147,7 +147,7 @@ module BetaBuilder
 #            system("zip -r '#{@configuration.ipa_name}' Payload")
 #          end
           
-          system("/usr/bin/xcrun -sdk iphoneos PackageApplication -v '#{@configuration.built_app_path}' -o '/tmp/#{@configuration.ipa_name}' --sign 'iPhone Distribution: Virtual World Computing, LLC' --embed adhoc.mobileprovision")
+          system("/usr/bin/xcrun -sdk iphoneos PackageApplication -v '#{@configuration.built_app_path}' -o '/tmp/#{@configuration.ipa_name}' --sign '#{@config.signing_identity}' --embed #{@configuration.provisioning_profile}")
 
           FileUtils.mkdir('pkg/dist')
           FileUtils.mv("/tmp/#{@configuration.ipa_name}", "pkg/dist")

--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -17,6 +17,7 @@ module BetaBuilder
         :xcodebuild_path => "xcodebuild",
         :project_file_path => nil,
         :workspace_path => nil,
+        :ipa_destination_path => "./",
         :scheme => nil,
         :app_name => nil,
         :arch => nil,
@@ -98,12 +99,8 @@ module BetaBuilder
         "#{built_app_path}.dSYM"
       end
       
-      def dist_path
-        File.join(derived_build_dir_from_build_output, "pkg")
-      end
-      
       def ipa_path
-        File.join(dist_path, ipa_name)
+        File.join(File.expand_path(ipa_destination_path), ipa_name)
       end
       
       def build_number_git
@@ -142,9 +139,7 @@ module BetaBuilder
           if @configuration.auto_archive
             Rake::Task["#{@namespace}:archive"].invoke
           end
-          
-          FileUtils.rm_rf("#{@configuration.dist_path}")
-          FileUtils.mkdir_p("#{@configuration.dist_path}")          
+               
           system("/usr/bin/xcrun -sdk iphoneos PackageApplication -v '#{@configuration.built_app_path}' -o '#{@configuration.ipa_path}' --sign '#{@configuration.signing_identity}' --embed #{@configuration.provisioning_profile}")
 
         end

--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -141,13 +141,16 @@ module BetaBuilder
           end
                     
           FileUtils.rm_rf('pkg') && FileUtils.mkdir_p('pkg')
-          FileUtils.mkdir_p("pkg/Payload")
-          FileUtils.mv(@configuration.built_app_path, "pkg/Payload/#{@configuration.app_file_name}")
-          Dir.chdir("pkg") do
-            system("zip -r '#{@configuration.ipa_name}' Payload")
-          end
+#          FileUtils.mkdir_p("pkg/Payload")
+#          FileUtils.mv(@configuration.built_app_path, "pkg/Payload/#{@configuration.app_file_name}")
+#          Dir.chdir("pkg") do
+#            system("zip -r '#{@configuration.ipa_name}' Payload")
+#          end
+          
+          system("/usr/bin/xcrun -sdk iphoneos PackageApplication -v '#{@configuration.built_app_path}' -o '/tmp/#{@configuration.ipa_name}' --sign 'iPhone Distribution: Virtual World Computing, LLC' --embed adhoc.mobileprovision")
+
           FileUtils.mkdir('pkg/dist')
-          FileUtils.mv("pkg/#{@configuration.ipa_name}", "pkg/dist")
+          FileUtils.mv("/tmp/#{@configuration.ipa_name}", "pkg/dist")
         end
         
         if @configuration.deployment_strategy

--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -15,6 +15,7 @@ module BetaBuilder
         :auto_archive => false,
         :archive_path  => File.expand_path("~/Library/Developer/Xcode/Archives"),
         :xcodebuild_path => "xcodebuild",
+        :xcodeargs => nil,
         :project_file_path => nil,
         :workspace_path => nil,
         :ipa_destination_path => "./",
@@ -54,9 +55,11 @@ module BetaBuilder
 
         args << " -arch \"#{arch}\"" unless arch.nil?
 
-        if set_version_number
-          args << " VERSION_LONG=#{build_number_git}"
-        end
+
+        args << " VERSION_LONG=#{build_number_git}" if set_version_number
+        
+        args << " #{xcodeargs}" unless xcodeargs.nil?
+
         
         args
       end

--- a/lib/beta_builder/archived_build.rb
+++ b/lib/beta_builder/archived_build.rb
@@ -1,6 +1,6 @@
 require 'uuid'
 require 'fileutils'
-require 'CFPropertyList'
+require 'cfpropertylist'
 
 module BetaBuilder
   def self.archive(configuration)

--- a/lib/beta_builder/archived_build.rb
+++ b/lib/beta_builder/archived_build.rb
@@ -76,7 +76,7 @@ module BetaBuilder
           "ApplicationPath"             => File.join("Applications", @configuration.app_file_name),
           "CFBundleIdentifier"          => metadata["CFBundleIdentifier"], 
           "CFBundleShortVersionString"  => version, 
-          "IconPaths"                   => metadata["CFBundleIconFiles"].map { |file| File.join("Applications", @configuration.app_file_name, file) }
+          "IconPaths"                   => metadata["CFBundleIcons"]["CFBundlePrimaryIcon"]["CFBundleIconFiles"].map { |file| File.join("Applications", @configuration.app_file_name, file) }
         }, 
         "ArchiveVersion" => 1.0, 
         "Comment"        => @configuration.release_notes_text,

--- a/lib/beta_builder/deployment_strategies/web.rb
+++ b/lib/beta_builder/deployment_strategies/web.rb
@@ -72,7 +72,7 @@ module BetaBuilder
   </head>
   <body>
     <div id="container">
-      <div class="link"><a href="itms-services://?action=download-manifest&url=#{@configuration.manifest_url}">Tap Here to Install<br />#{@configuration.target}<br />On Your Device</a></div>
+      <div class="link"><a href="itms-services://?action=download-manifest&url=#{@configuration.manifest_url}">Tap Here to Install<br />#{@configuration.target} #{plist_data['CFBundleVersion']}<br />On Your Device</a></div>
       <p><strong>Link didn't work?</strong><br />
 	Make sure you're visiting this page on your device, not your computer.</p>
     </div>

--- a/lib/beta_builder/deployment_strategies/web.rb
+++ b/lib/beta_builder/deployment_strategies/web.rb
@@ -4,21 +4,21 @@ module BetaBuilder
       def extended_configuration_for_strategy
         proc do
           def deployment_url
-            File.join(deploy_to, target.downcase, ipa_name)
+            File.join(deploy_to, ipa_name)
           end
 
           def manifest_url
-            File.join(deploy_to, target.downcase, "manifest.plist")
+            File.join(deploy_to, "manifest.plist")
           end
 
           def remote_installation_path
-            File.join(remote_directory, target.downcase)
+            File.join(remote_directory)
           end
         end
       end
       
       def prepare
-        plist = CFPropertyList::List.new(:file => "pkg/Payload/#{@configuration.app_name}/Info.plist")
+        plist = CFPropertyList::List.new(:file => "pkg/Payload/#{@configuration.app_name}.app/Info.plist")
         plist_data = CFPropertyList.native_types(plist.value)
         File.open("pkg/dist/manifest.plist", "w") do |io|
           io << %{

--- a/lib/beta_builder/deployment_strategies/web.rb
+++ b/lib/beta_builder/deployment_strategies/web.rb
@@ -18,7 +18,7 @@ module BetaBuilder
       end
       
       def prepare
-        plist = CFPropertyList::List.new(:file => "pkg/Payload/#{@configuration.app_name}.app/Info.plist")
+        plist = CFPropertyList::List.new(:file => "#{@configuration.built_app_path}/Info.plist")
         plist_data = CFPropertyList.native_types(plist.value)
         File.open("pkg/dist/manifest.plist", "w") do |io|
           io << %{

--- a/lib/beta_builder/deployment_strategies/web.rb
+++ b/lib/beta_builder/deployment_strategies/web.rb
@@ -21,65 +21,64 @@ module BetaBuilder
         plist = CFPropertyList::List.new(:file => "#{@configuration.built_app_path}/Info.plist")
         plist_data = CFPropertyList.native_types(plist.value)
         File.open("pkg/dist/manifest.plist", "w") do |io|
-          io << %{
-            <?xml version="1.0" encoding="UTF-8"?>
-            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-            <plist version="1.0">
-            <dict>
-              <key>items</key>
-              <array>
-                <dict>
-                  <key>assets</key>
-                  <array>
-                    <dict>
-                      <key>kind</key>
-                      <string>software-package</string>
-                      <key>url</key>
-                      <string>#{@configuration.deployment_url}</string>
-                    </dict>
-                  </array>
-                  <key>metadata</key>
-                  <dict>
-                    <key>bundle-identifier</key>
-                    <string>#{plist_data['CFBundleIdentifier']}</string>
-                    <key>bundle-version</key>
-                    <string>#{plist_data['CFBundleVersion']}</string>
-                    <key>kind</key>
-                    <string>software</string>
-                    <key>title</key>
-                    <string>#{plist_data['CFBundleDisplayName']}</string>
-                  </dict>
-                </dict>
-              </array>
-            </dict>
-            </plist>
-          }
+          io << %{<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>items</key>
+    <array>
+      <dict>
+        <key>assets</key>
+        <array>
+          <dict>
+            <key>kind</key>
+            <string>software-package</string>
+            <key>url</key>
+            <string>#{@configuration.deployment_url}</string>
+          </dict>
+        </array>
+        <key>metadata</key>
+        <dict>
+          <key>bundle-identifier</key>
+          <string>#{plist_data['CFBundleIdentifier']}</string>
+          <key>bundle-version</key>
+          <string>#{plist_data['CFBundleVersion']}</string>
+          <key>kind</key>
+          <string>software</string>
+          <key>title</key>
+          <string>#{plist_data['CFBundleDisplayName']}</string>
+        </dict>
+      </dict>
+    </array>
+  </dict>
+</plist>
+}
         end
         File.open("pkg/dist/index.html", "w") do |io|
-          io << %{
-            <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-            <html xmlns="http://www.w3.org/1999/xhtml">
-            <head>
-            <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-            <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
-            <title>Beta Download</title>
-            <style type="text/css">
-            body {background:#fff;margin:0;padding:0;font-family:arial,helvetica,sans-serif;text-align:center;padding:10px;color:#333;font-size:16px;}
-            #container {width:300px;margin:0 auto;}
-            h1 {margin:0;padding:0;font-size:14px;}
-            p {font-size:13px;}
-            .link {background:#ecf5ff;border-top:1px solid #fff;border:1px solid #dfebf8;margin-top:.5em;padding:.3em;}
-            .link a {text-decoration:none;font-size:15px;display:block;color:#069;}
-            </style>
-            </head>
-            <body>
-            <div id="container">
-            <div class="link"><a href="itms-services://?action=download-manifest&url=#{@configuration.manifest_url}">Tap Here to Install<br />#{@configuration.target}<br />On Your Device</a></div>
-            <p><strong>Link didn't work?</strong><br />
-            Make sure you're visiting this page on your device, not your computer.</p>
-            </body>
-            </html>
-          }
+          io << %{<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"/>
+    <title>Beta Download</title>
+    <style type="text/css">
+      body {background:#fff;margin:0;padding:0;font-family:arial,helvetica,sans-serif;text-align:center;padding:10px;color:#333;font-size:16px;}
+      #container {width:300px;margin:0 auto;}
+      h1 {margin:0;padding:0;font-size:14px;}
+      p {font-size:13px;}
+      .link {background:#ecf5ff;border-top:1px solid #fff;border:1px solid #dfebf8;margin-top:.5em;padding:.3em;}
+      .link a {text-decoration:none;font-size:15px;display:block;color:#069;}
+    </style>
+  </head>
+  <body>
+    <div id="container">
+      <div class="link"><a href="itms-services://?action=download-manifest&url=#{@configuration.manifest_url}">Tap Here to Install<br />#{@configuration.target}<br />On Your Device</a></div>
+      <p><strong>Link didn't work?</strong><br />
+	Make sure you're visiting this page on your device, not your computer.</p>
+    </div>
+  </body>
+</html>
+}
         end
       end
       


### PR DESCRIPTION
CFBundleIconFiles was causing errors when attempting to archive.  Changing the mapping to reflect the plist structure Xcode generated fixed it.

This might need to be made more intelligent and pick which metadata is appropriate depending on what's available.
