### PR TITLE
Fixingand adding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,6 @@
 * Fixes cases where CFPropertyList could fail to load (@svelix)
 * Uses relative paths for requires (@smtlaissezfaire)
 * Raises an exception if the build fails (@epall)
-* Improved method for locating the DerivedData location (@drodriguez)
 
 
 ## 0.7.4.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 * Fixes cases where CFPropertyList could fail to load (@svelix)
 * Uses relative paths for requires (@smtlaissezfaire)
 * Raises an exception if the build fails (@epall)
+* Improved method for locating the DerivedData location (@drodriguez)
 
 
 ## 0.7.4.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,17 @@
 ## 0.7.5
 * Allows automation of version/build number setting
+* Adds full paths to xcodebuild and xcrun; they are override-able in the config
+* Adds ability to add arguments to package command
+* Refactors commands and argument code
+* Makes build and signing output optional (use config.verbose to trigger) 
+* Adds simplified output
 * Allows custom SCP ports (@smtlaissezfaire)
 * Fixes Archive task failure (@rennarda)
 * Uses Apple's Packager to produce valid IPAs (@dts)
 * Fixes cases where CFPropertyList could fail to load (@svelix)
 * Uses relative paths for requires (@smtlaissezfaire)
 * Raises an exception if the build fails (@epall)
+
 
 ## 0.7.4.1
 * Allow auto-archiving from other Rake namespaces (@victor)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## 0.7.5
+* Allows automation of version/build number setting
+* Allows custom SCP ports (@smtlaissezfaire)
+* Fixes Archive task failure (@rennarda)
+* Uses Apple's Packager to produce valid IPAs (@dts)
+* Fixes cases where CFPropertyList could fail to load (@svelix)
+* Uses relative paths for requires (@smtlaissezfaire)
+* Raises an exception if the build fails (@epall)
+
 ## 0.7.4.1
 * Allow auto-archiving from other Rake namespaces (@victor)
 * Fixed bug with Xcode archive sharing (@victor)

--- a/README.md
+++ b/README.md
@@ -123,6 +123,20 @@ SSH keys will simplify authentication and make this process seamless
 
 `remote_installation_path` - (String) Remote Path
 
+### Configuration (RunTime)
+Certain configuration options are availabe at the command line, so that you can temporarily set them for a single run without modifying your configuration.
+
+Pass any of these in as environment variables:
+
+`DRY` - (true/**false**) Enable Dry Run
+`VERBOSE` - (true/**false**) Turn on all output; lets you see the clean, build, and signing output
+`SKIPCLEAN` - (true/**false**) Skips the clean step and goes right to Build.
+
+####Examples
+
+`rake staging:deploy DRY=true`
+
+`rake staging:redeploy VERBOSE=true SKIPCLEAN=true`
 
 ## Xcode 4 support
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,52 @@ To use a namespace other than "beta" for the generated tasks, simply pass in you
     
 This lets you set up different sets of BetaBuilder tasks for different configurations in the same Rakefile (e.g. a production and staging build).
 
+## Configuration
+A full list of configuration options and their details
+
+`configuration` - (String) The Xcode Configuration to use (Defined on the Info tab of the Project)
+
+`build_dir` - (File Path) The directory the build output will be. (`:derived` for Xcode 4 for versions < 0.8)
+
+`auto_archive` - (true/**false**) Automatically archive when packaging
+
+`archive_path` - (File Path) Path to the Archives
+
+`xcodebuild_path` - (File Path) Path to xcodebuild, if its non-standard
+
+`xcodeargs` - (Arguments) Arguments passed to `xcodebuild` when it runs
+
+`project_file_path` - (File Path) Path to the `.xcodeproj` file
+
+`workspace_path` - (File Path) Path to the `.xcworkspace` file
+
+`ipa_destination_path` - (File Path) Path to output Packaged IPA to
+
+`scheme` - (String) What Scheme to use when building
+
+`app_name` - (String) The name of the app being built (should match the file name, less the `.app` extension)
+
+`arch` - (String) The architecture to build for, if different from project settings
+
+`xcode4_archive_mode` - (true/**false**) Use Xcode4's Archive mode
+
+`skip_clean` - (true/**false**) Skip the clean step when building
+
+`verbose` - (true/**false**) Increased output for debugging
+
+`dry_run` - (true/**false**) Don't upload to Distribution Strategy, just act like it
+
+`set_version_number` - (true/**false**) Attempts to set a version number, see below
+
+### Configuration (Testflight)
+Testflight presents its own set of options that can be configured
+
+`api_token` - (String) Can be your API key, but its recommended to use an `ENV[""]` variable
+`team_token` - (String) Your Team's Testflight API token
+`distribution_lists` - (Array) A Ruby array (`[1,2]` or `%w{1 2}`) of distribution list names for Testflight
+`notify` - (true/**false**) Notify the distribution list of this build
+`replace` - (true/**false**) Replace if an existing build exists with the same ID and version
+
 ## Xcode 4 support
 
 Betabuilder works with Xcode 4, but you may need to tweak your task configuration slightly. The most important change you will need to make is the build directory location, unless you have configured Xcode 4 to use the "build" directory relative to your project, as in Xcode 3.
@@ -81,12 +127,28 @@ If you are working with an Xcode 4 workspace instead of a project file, you will
     config.workspace_path = "MyWorkspace.xcworkspace"
     config.scheme         = "My App Scheme"
     config.app_name       = "MyApp"
-    
+    set_version_number
 If you are using a workspace, then you must specify the scheme. You can still specify the build configuration (e.g. Release).
 
 ## Automatic deployment with deployment strategies
 
 BetaBuilder allows you to deploy your built package using it's extensible deployment strategy system; the gem currently comes with support for simple web-based deployment or uploading to [TestFlightApp.com](http://www.testflightapp.com). Eventually, you will be able to write your own custom deployment strategies if neither of these are suitable for your needs.
+
+## Setting version numbers automatically
+
+You can use betabuilder to set a build number using Git's `describe` system.  In order for that to work, at least one `tag` must exist somewhere in the git hierarchy for the branch being built from. 
+
+Also, you are required to set your `CFBundleVersion` to `${VERSION_LONG}` inside your `Info.plist`.  To accomodate manual builds, add a `VERSION_LONG` Build Setting to your app's Project, and treat it as you normally would your `Info.plist` version number.
+
+Once a tag is created and your App is configured, simply add this to your BetaBuilder config and it will use Git to generate the 
+
+	config.set_version_number = true
+
+It will generate a version number like: `1.0-15-g6b3c1bb`. 
+
+* *1.0* is the most recent tag
+* *15* is the number of commits since the tag was generated
+* *g6b3c1bb* is the beginning of the hash of the last commit.
 
 ### Deploying your app with TestFlight
 

--- a/README.md
+++ b/README.md
@@ -103,10 +103,26 @@ A full list of configuration options and their details
 Testflight presents its own set of options that can be configured
 
 `api_token` - (String) Can be your API key, but its recommended to use an `ENV[""]` variable
+
 `team_token` - (String) Your Team's Testflight API token
+
 `distribution_lists` - (Array) A Ruby array (`[1,2]` or `%w{1 2}`) of distribution list names for Testflight
+
 `notify` - (true/**false**) Notify the distribution list of this build
+
 `replace` - (true/**false**) Replace if an existing build exists with the same ID and version
+
+### Configuration (Web)
+Pushing to a web server has the following options.
+
+SSH keys will simplify authentication and make this process seamless
+
+`remote_host` - (String) Hostname for the server the build will be pushed to
+
+`remote_port` - (String) Port Number to use for SCP/SFTP
+
+`remote_installation_path` - (String) Remote Path
+
 
 ## Xcode 4 support
 

--- a/Rakefile
+++ b/Rakefile
@@ -15,11 +15,11 @@ spec = Gem::Specification.new do |s|
 
   # Change these as appropriate
   s.name              = "betabuilder"
-  s.version           = "0.7.4.1"
+  s.version           = "0.7.5"
   s.summary           = "A set of Rake tasks and utilities for managing iOS ad-hoc builds"
-  s.author            = "Luke Redpath"
-  s.email             = "luke@lukeredpath.co.uk"
-  s.homepage          = "http://github.com/lukeredpath/betabuilder"
+  s.authors           = ["Luke Redpath", "Nick Peelman"]
+  s.email             = ["luke@lukeredpath.co.uk", "nick@peelman.us"]
+  s.homepage          = "http://github.com/peelman/betabuilder"
 
   s.has_rdoc          = false
   s.extra_rdoc_files  = %w(README.md LICENSE CHANGES.md)

--- a/betabuilder.gemspec
+++ b/betabuilder.gemspec
@@ -1,20 +1,20 @@
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |s|
-  s.name = "betabuilder"
-  s.version = "0.7.4.1"
-
+  s.name              = "betabuilder"
+  s.version           = "0.7.5"
+  s.summary           = "A set of Rake tasks and utilities for managing iOS ad-hoc builds"
+  s.authors           = ["Luke Redpath", "Nick Peelman"]
+  s.email             = ["luke@lukeredpath.co.uk", "nick@peelman.us"]
+  s.homepage          = "http://github.com/peelman/betabuilder"
+  
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = ["Luke Redpath"]
-  s.date = "2011-11-16"
-  s.email = "luke@lukeredpath.co.uk"
+  s.date = "2012-04-25"
   s.extra_rdoc_files = ["README.md", "LICENSE", "CHANGES.md"]
   s.files = ["CHANGES.md", "LICENSE", "README.md", "lib/beta_builder/archived_build.rb", "lib/beta_builder/build_output_parser.rb", "lib/beta_builder/deployment_strategies/testflight.rb", "lib/beta_builder/deployment_strategies/web.rb", "lib/beta_builder/deployment_strategies.rb", "lib/beta_builder.rb", "lib/betabuilder.rb"]
-  s.homepage = "http://github.com/lukeredpath/betabuilder"
   s.rdoc_options = ["--main", "README.md"]
   s.require_paths = ["lib"]
   s.rubygems_version = "1.8.11"
-  s.summary = "A set of Rake tasks and utilities for managing iOS ad-hoc builds"
 
   if s.respond_to? :specification_version then
     s.specification_version = 3

--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -40,7 +40,7 @@ module BetaBuilder
       cmd = []
       cmd << @configuration.xcodebuild_path
       cmd.concat args
-      puts "Running: #{cmd.join("")}" if @configuration.verbose
+      puts "Running: #{cmd.join(" ")}" if @configuration.verbose
       cmd << "2>&1 %s build.output" % (@configuration.verbose ? '| tee' : '>')
       cmd = cmd.join(" ")
       system(cmd)
@@ -68,8 +68,8 @@ module BetaBuilder
         args << "VERSION_LONG='#{build_number_git}'" if set_version_number
         
         if xcodeargs
-            args.concat xcodeargs if xcodeargs.is_an Array
-            args << "#{xcodeargs}" if xcodears.is_a String
+            args.concat xcodeargs if xcodeargs.is_a? Array
+            args << "#{xcodeargs}" if xcodears.is_a? String
         end
         
         args
@@ -171,8 +171,8 @@ module BetaBuilder
           cmd << "--sign '#{@configuration.signing_identity}'"
           cmd << "--embed '#{@configuration.provisioning_profile}'"
           if @configuration.packageargs
-            cmd.concat @configuration.packageargs if @configuration.packageargs.is_an Array
-            cmd << @configuration.packageargs if @configuration.packageargs.is_a String
+            cmd.concat @configuration.packageargs if @configuration.packageargs.is_a? Array
+            cmd << @configuration.packageargs if @configuration.packageargs.is_a? String
           end
           puts "Running #{cmd.join(" ")}" if @configuration.verbose
           cmd << "2>&1 %s build.output" % (@configuration.verbose ? '| tee' : '>')

--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -143,7 +143,7 @@ module BetaBuilder
             Rake::Task["#{@namespace}:archive"].invoke
           end
                
-          system("/usr/bin/xcrun -sdk iphoneos PackageApplication -v '#{@configuration.built_app_path}' -o '#{@configuration.ipa_path}' --sign '#{@configuration.signing_identity}' --embed #{@configuration.provisioning_profile}")
+          system("/usr/bin/xcrun -sdk iphoneos PackageApplication -v '#{@configuration.built_app_path}' -o '#{@configuration.ipa_path}' --sign '#{@configuration.signing_identity}' --embed '#{@configuration.provisioning_profile}'")
 
         end
         

--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -147,7 +147,7 @@ module BetaBuilder
 #            system("zip -r '#{@configuration.ipa_name}' Payload")
 #          end
           
-          system("/usr/bin/xcrun -sdk iphoneos PackageApplication -v '#{@configuration.built_app_path}' -o '/tmp/#{@configuration.ipa_name}' --sign '#{@config.signing_identity}' --embed #{@configuration.provisioning_profile}")
+          system("/usr/bin/xcrun -sdk iphoneos PackageApplication -v '#{@configuration.built_app_path}' -o '/tmp/#{@configuration.ipa_name}' --sign '#{@configuration.signing_identity}' --embed #{@configuration.provisioning_profile}")
 
           FileUtils.mkdir('pkg/dist')
           FileUtils.mv("/tmp/#{@configuration.ipa_name}", "pkg/dist")

--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -87,9 +87,9 @@ module BetaBuilder
       
       def built_app_path
         if build_dir == :derived
-          "#{derived_build_dir_from_build_output}/#{configuration}-iphoneos/#{app_file_name}"
+          File.join("#{derived_build_dir_from_build_output}", "#{configuration}-iphoneos", "#{app_file_name}")
         else
-          "#{build_dir}/#{configuration}-iphoneos/#{app_file_name}"
+          File.join("#{build_dir}", "#{configuration}-iphoneos", "#{app_file_name}")
         end
       end
       

--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -149,7 +149,15 @@ module BetaBuilder
           FileUtils.mkdir('pkg/dist')
           FileUtils.mv("pkg/#{@configuration.ipa_name}", "pkg/dist")
         end
-        
+
+        desc "Build and archive the app"
+        task :archive => :build do
+          puts "Archiving build..."
+          archive = BetaBuilder.archive(@configuration)
+          output_path = archive.save_to(@configuration.archive_path)
+          puts "Archive saved to #{output_path}."
+        end
+
         if @configuration.deployment_strategy
           desc "Prepare your app for deployment"
           task :prepare => :package do
@@ -168,13 +176,7 @@ module BetaBuilder
           end
         end
         
-        desc "Build and archive the app"
-        task :archive => :build do
-          puts "Archiving build..."
-          archive = BetaBuilder.archive(@configuration)
-          output_path = archive.save_to(@configuration.archive_path)
-          puts "Archive saved to #{output_path}."
-        end
+
       end
     end
   end

--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -25,9 +25,9 @@ module BetaBuilder
         :app_name => nil,
         :arch => nil,
         :xcode4_archive_mode => false,
-        :skip_clean => ENV['SKIPCLEAN'] || false,
-        :verbose => ENV['VERBOSE'] || false,
-        :dry_run => ENV['DRY'] || false,
+        :skip_clean => ENV.fetch('SKIPCLEAN', false),
+        :verbose => ENV.fetch('VERBOSE', false),
+        :dry_run => ENV.fetch('DRY', false),
         :set_version_number => false
       )
       @namespace = namespace

--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -118,7 +118,7 @@ module BetaBuilder
       end
       
       def build_number_git
-        `git describe --tags --long`.chop
+        `git describe --tags --abbrev=1`.chop
       end
       
       def deploy_using(strategy_name, &block)

--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -94,42 +94,19 @@ module BetaBuilder
         else
           "#{target}.ipa"
         end
-      end
+      end      
       
       def built_app_path
         if build_dir == :derived
-          File.join("#{derived_build_dir}", "#{configuration}-iphoneos", "#{app_file_name}")
+          File.join("#{derived_build_dir_from_build_output}", "#{configuration}-iphoneos", "#{app_file_name}")
         else
           File.join("#{build_dir}", "#{configuration}-iphoneos", "#{app_file_name}")
         end
       end
       
-      def derived_build_dir
-        workspace_settings_path = File.join(workspace_path, 'xcuserdata',
-                                            "#{`whoami`.strip}.xcuserdatad",
-                                            'WorkspaceSettings.xcsettings')
-
-        # Check the derived data location style
-        workspace_settings = CFPropertyList.native_types(
-          CFPropertyList::List.new(:file => workspace_settings_path).value)
-        derived_data_location_style = workspace_settings['IDEWorkspaceUserSettings_DerivedDataLocationStyle']
-        derived_data_directory = case derived_data_location_style
-          when 0 then # The standard DerivedData directory.
-            workspace_name = File.basename(workspace_path, '.xcworkspace')
-            derived_data_dir = File.expand_path('~/Library/Developer/Xcode/DerivedData')
-
-            # Look in every directory named after our workspace for the
-            # info.plist that points back to our workspace.
-            Dir[File.join(derived_data_dir, "#{workspace_name}-*")].find do |d|
-              CFPropertyList.native_types(CFPropertyList::List.new(:file => "#{d}/info.plist").value)['WorkspacePath'] == workspace_path
-            end
-          when 1, 2 then # We have the full path, or relative path
-            workspace_settings['IDEWorkspaceUserSettings_DerivedDataCustomLocation']
-          else
-            raise "Unable to determine the DerivedData path. Your Workspace may be invalid or corrupted"
-          end
-
-        "#{derived_data_directory}/Build/Products/"
+      def derived_build_dir_from_build_output
+        output = BuildOutputParser.new(File.read("build.output"))
+        output.build_output_dir  
       end
       
       def built_app_dsym_path

--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -147,7 +147,7 @@ module BetaBuilder
 #            system("zip -r '#{@configuration.ipa_name}' Payload")
 #          end
           
-          system("/usr/bin/xcrun -sdk iphoneos PackageApplication -v '#{@configuration.built_app_path}' -o '/tmp/#{@configuration.ipa_name}' --sign 'iPhone Distribution: Virtual World Computing, LLC' --embed adhoc.mobileprovision")
+          system("/usr/bin/xcrun -sdk iphoneos PackageApplication -v '#{@configuration.built_app_path}' -o '/tmp/#{@configuration.ipa_name}' --sign '#{@config.signing_identity}' --embed #{@configuration.provisioning_profile}")
 
           FileUtils.mkdir('pkg/dist')
           FileUtils.mv("/tmp/#{@configuration.ipa_name}", "pkg/dist")

--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -17,6 +17,7 @@ module BetaBuilder
         :xcodebuild_path => "xcodebuild",
         :project_file_path => nil,
         :workspace_path => nil,
+        :ipa_destination_path => "./",
         :scheme => nil,
         :app_name => nil,
         :arch => nil,
@@ -98,12 +99,8 @@ module BetaBuilder
         "#{built_app_path}.dSYM"
       end
       
-      def dist_path
-        File.join(derived_build_dir_from_build_output, "pkg")
-      end
-      
       def ipa_path
-        File.join(dist_path, ipa_name)
+        File.join(File.expand_path(ipa_destination_path), ipa_name)
       end
       
       def build_number_git
@@ -142,9 +139,7 @@ module BetaBuilder
           if @configuration.auto_archive
             Rake::Task["#{@namespace}:archive"].invoke
           end
-          
-          FileUtils.rm_rf("#{@configuration.dist_path}")
-          FileUtils.mkdir_p("#{@configuration.dist_path}")          
+               
           system("/usr/bin/xcrun -sdk iphoneos PackageApplication -v '#{@configuration.built_app_path}' -o '#{@configuration.ipa_path}' --sign '#{@configuration.signing_identity}' --embed #{@configuration.provisioning_profile}")
 
         end

--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -32,7 +32,7 @@ module BetaBuilder
 
     def xcodebuild(*args)
       # we're using tee as we still want to see our build output on screen
-      system("#{@configuration.xcodebuild_path} #{args.join(" ")} | tee build.output")
+      system("#{@configuration.xcodebuild_path} #{args.join(" ")} 2>&1 | tee build.output")
     end
 
     class Configuration < OpenStruct
@@ -118,6 +118,7 @@ module BetaBuilder
         desc "Build the beta release of the app"
         task :build => :clean do
           xcodebuild @configuration.build_arguments, "build"
+          raise "** BUILD FAILED **" if BuildOutputParser.new(File.read("build.output")).failed?
         end
         
         task :clean do

--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -25,9 +25,9 @@ module BetaBuilder
         :app_name => nil,
         :arch => nil,
         :xcode4_archive_mode => false,
-        :skip_clean => false,
-        :verbose => false,
-        :dry_run => false,
+        :skip_clean => ENV['SKIPCLEAN'] || false,
+        :verbose => ENV['VERBOSE'] || false,
+        :dry_run => ENV['DRY'] || false,
         :set_version_number => false
       )
       @namespace = namespace

--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -141,13 +141,16 @@ module BetaBuilder
           end
                     
           FileUtils.rm_rf('pkg') && FileUtils.mkdir_p('pkg')
-          FileUtils.mkdir_p("pkg/Payload")
-          FileUtils.mv(@configuration.built_app_path, "pkg/Payload/#{@configuration.app_file_name}")
-          Dir.chdir("pkg") do
-            system("zip -r '#{@configuration.ipa_name}' Payload")
-          end
+#          FileUtils.mkdir_p("pkg/Payload")
+#          FileUtils.mv(@configuration.built_app_path, "pkg/Payload/#{@configuration.app_file_name}")
+#          Dir.chdir("pkg") do
+#            system("zip -r '#{@configuration.ipa_name}' Payload")
+#          end
+          
+          system("/usr/bin/xcrun -sdk iphoneos PackageApplication -v '#{@configuration.built_app_path}' -o '/tmp/#{@configuration.ipa_name}' --sign 'iPhone Distribution: Virtual World Computing, LLC' --embed adhoc.mobileprovision")
+
           FileUtils.mkdir('pkg/dist')
-          FileUtils.mv("pkg/#{@configuration.ipa_name}", "pkg/dist")
+          FileUtils.mv("/tmp/#{@configuration.ipa_name}", "pkg/dist")
         end
         
         if @configuration.deployment_strategy

--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -15,6 +15,7 @@ module BetaBuilder
         :auto_archive => false,
         :archive_path  => File.expand_path("~/Library/Developer/Xcode/Archives"),
         :xcodebuild_path => "xcodebuild",
+        :xcodeargs => nil,
         :project_file_path => nil,
         :workspace_path => nil,
         :ipa_destination_path => "./",
@@ -54,9 +55,11 @@ module BetaBuilder
 
         args << " -arch \"#{arch}\"" unless arch.nil?
 
-        if set_version_number
-          args << " VERSION_LONG=#{build_number_git}"
-        end
+
+        args << " VERSION_LONG=#{build_number_git}" if set_version_number
+        
+        args << " #{xcodeargs}" unless xcodeargs.nil?
+
         
         args
       end

--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -142,8 +142,22 @@ module BetaBuilder
           if @configuration.auto_archive
             Rake::Task["#{@namespace}:archive"].invoke
           end
-               
-          system("/usr/bin/xcrun -sdk iphoneos PackageApplication -v '#{@configuration.built_app_path}' -o '#{@configuration.ipa_path}' --sign '#{@configuration.signing_identity}' --embed '#{@configuration.provisioning_profile}'")
+          
+          raise "** PACKAGE FAILED ** No Signing Identity Found" unless @configuration.signing_identity
+          raise "** PACKAGE FAILED ** No Provisioning Profile Found" unless @configuration.provisioning_profile
+          
+          # Construct the IPA and Sign it
+          cmd = []
+          cmd.push "/usr/bin/xcrun"
+          cmd.push "-sdk iphoneos"
+          cmd.push "PackageApplication"
+          cmd.push "-v '#{@configuration.built_app_path}'"
+          cmd.push "-o '#{@configuration.ipa_path}'"
+          cmd.push "--sign '#{@configuration.signing_identity}'"
+          cmd.push "--embed '#{@configuration.provisioning_profile}'"
+          cmd = cmd.join(" ")
+          puts "Running #{cmd}"
+          system(cmd)
 
         end
 

--- a/lib/beta_builder/archived_build.rb
+++ b/lib/beta_builder/archived_build.rb
@@ -1,6 +1,6 @@
 require 'uuid'
 require 'fileutils'
-require 'CFPropertyList'
+require 'cfpropertylist'
 
 module BetaBuilder
   def self.archive(configuration)

--- a/lib/beta_builder/archived_build.rb
+++ b/lib/beta_builder/archived_build.rb
@@ -76,7 +76,7 @@ module BetaBuilder
           "ApplicationPath"             => File.join("Applications", @configuration.app_file_name),
           "CFBundleIdentifier"          => metadata["CFBundleIdentifier"], 
           "CFBundleShortVersionString"  => version, 
-          "IconPaths"                   => metadata["CFBundleIconFiles"].map { |file| File.join("Applications", @configuration.app_file_name, file) }
+          "IconPaths"                   => metadata["CFBundleIcons"]["CFBundlePrimaryIcon"]["CFBundleIconFiles"].map { |file| File.join("Applications", @configuration.app_file_name, file) }
         }, 
         "ArchiveVersion" => 1.0, 
         "Comment"        => @configuration.release_notes_text,

--- a/lib/beta_builder/build_output_parser.rb
+++ b/lib/beta_builder/build_output_parser.rb
@@ -16,6 +16,10 @@ module BetaBuilder
       derived_data_directory = reference.split("/Build/Products/").first
       "#{derived_data_directory}/Build/Products/"
     end
+
+    def failed?
+      @output.split("\n").any? {|line| line.include? "** BUILD FAILED **"}
+    end
   end
 end
 

--- a/lib/beta_builder/deployment_strategies.rb
+++ b/lib/beta_builder/deployment_strategies.rb
@@ -22,7 +22,7 @@ module BetaBuilder
       end
 
       def prepare
-        puts "Nothing to prepare!"
+        puts "Nothing to prepare!" if @configuration.verbose
       end
     end
 

--- a/lib/beta_builder/deployment_strategies.rb
+++ b/lib/beta_builder/deployment_strategies.rb
@@ -34,6 +34,6 @@ module BetaBuilder
   end
 end
 
-require 'beta_builder/deployment_strategies/web'
-require 'beta_builder/deployment_strategies/testflight'
+require File.dirname(__FILE__) + '/deployment_strategies/web'
+require File.dirname(__FILE__) + '/deployment_strategies/testflight'
 

--- a/lib/beta_builder/deployment_strategies/testflight.rb
+++ b/lib/beta_builder/deployment_strategies/testflight.rb
@@ -27,7 +27,6 @@ module BetaBuilder
           :notify             => @configuration.notify || false,
           :replace            => @configuration.replace || false
         }
-        puts "Uploading build to TestFlight..."
         if @configuration.verbose
           puts "ipa path: #{@configuration.ipa_path}"
           puts "release notes: #{release_notes}"
@@ -38,6 +37,8 @@ module BetaBuilder
           return
         end
         
+        print "Uploading build to TestFlight..."        
+        
         begin
           response = RestClient.post(ENDPOINT, payload, :accept => :json)
         rescue => e
@@ -45,9 +46,10 @@ module BetaBuilder
         end
         
         if (response.code == 201) || (response.code == 200)
-          puts "Upload complete."
+          puts "Done."
         else
-          puts "Upload failed. (#{response})"
+          puts "Failed."
+          puts "#{response}"
         end
       end
       

--- a/lib/beta_builder/deployment_strategies/testflight.rb
+++ b/lib/beta_builder/deployment_strategies/testflight.rb
@@ -6,6 +6,8 @@ require 'fileutils'
 module BetaBuilder
   module DeploymentStrategies
     class TestFlight < Strategy
+      include Rake::DSL
+      include FileUtils
       ENDPOINT = "https://testflightapp.com/api/builds.json"
       
       def extended_configuration_for_strategy

--- a/lib/beta_builder/deployment_strategies/web.rb
+++ b/lib/beta_builder/deployment_strategies/web.rb
@@ -16,7 +16,7 @@ module BetaBuilder
           end
         end
       end
-      
+
       def prepare
         plist = CFPropertyList::List.new(:file => "pkg/Payload/#{@configuration.app_name}/Info.plist")
         plist_data = CFPropertyList.native_types(plist.value)
@@ -82,9 +82,20 @@ module BetaBuilder
           }
         end
       end
-      
+
       def deploy
-        system("scp pkg/dist/* #{@configuration.remote_host}:#{@configuration.remote_installation_path}")
+        cmd = []
+
+        cmd.push "scp"
+
+        if @configuration.remote_port
+          cmd.push "-P #{@configuration.remote_port}"
+        end
+
+        cmd.push "pkg/dist/*"
+        cmd.push "#{@configuration.remote_host}:#{@configuration.remote_installation_path}"
+
+        system(cmd.join(" "))
       end
     end
   end

--- a/lib/beta_builder/deployment_strategies/web.rb
+++ b/lib/beta_builder/deployment_strategies/web.rb
@@ -72,7 +72,7 @@ module BetaBuilder
   </head>
   <body>
     <div id="container">
-      <div class="link"><a href="itms-services://?action=download-manifest&url=#{@configuration.manifest_url}">Tap Here to Install<br />#{@configuration.target}<br />On Your Device</a></div>
+      <div class="link"><a href="itms-services://?action=download-manifest&url=#{@configuration.manifest_url}">Tap Here to Install<br />#{@configuration.target} #{plist_data['CFBundleVersion']}<br />On Your Device</a></div>
       <p><strong>Link didn't work?</strong><br />
 	Make sure you're visiting this page on your device, not your computer.</p>
     </div>

--- a/lib/beta_builder/deployment_strategies/web.rb
+++ b/lib/beta_builder/deployment_strategies/web.rb
@@ -18,7 +18,7 @@ module BetaBuilder
       end
 
       def prepare
-        plist = CFPropertyList::List.new(:file => "pkg/Payload/#{@configuration.app_name}/Info.plist")
+        plist = CFPropertyList::List.new(:file => "pkg/Payload/#{@configuration.app_file_name}/Info.plist")
         plist_data = CFPropertyList.native_types(plist.value)
         File.open("pkg/dist/manifest.plist", "w") do |io|
           io << %{
@@ -95,7 +95,10 @@ module BetaBuilder
         cmd.push "pkg/dist/*"
         cmd.push "#{@configuration.remote_host}:#{@configuration.remote_installation_path}"
 
-        system(cmd.join(" "))
+        cmd = cmd.join(" ")
+
+        puts "* Running `#{cmd}`"
+        system(cmd)
       end
     end
   end

--- a/lib/beta_builder/deployment_strategies/web.rb
+++ b/lib/beta_builder/deployment_strategies/web.rb
@@ -4,21 +4,21 @@ module BetaBuilder
       def extended_configuration_for_strategy
         proc do
           def deployment_url
-            File.join(deploy_to, target.downcase, ipa_name)
+            File.join(deploy_to, ipa_name)
           end
 
           def manifest_url
-            File.join(deploy_to, target.downcase, "manifest.plist")
+            File.join(deploy_to, "manifest.plist")
           end
 
           def remote_installation_path
-            File.join(remote_directory, target.downcase)
+            File.join(remote_directory)
           end
         end
       end
       
       def prepare
-        plist = CFPropertyList::List.new(:file => "pkg/Payload/#{@configuration.app_name}/Info.plist")
+        plist = CFPropertyList::List.new(:file => "pkg/Payload/#{@configuration.app_name}.app/Info.plist")
         plist_data = CFPropertyList.native_types(plist.value)
         File.open("pkg/dist/manifest.plist", "w") do |io|
           io << %{

--- a/lib/beta_builder/deployment_strategies/web.rb
+++ b/lib/beta_builder/deployment_strategies/web.rb
@@ -18,7 +18,7 @@ module BetaBuilder
       end
       
       def prepare
-        plist = CFPropertyList::List.new(:file => "pkg/Payload/#{@configuration.app_name}.app/Info.plist")
+        plist = CFPropertyList::List.new(:file => "#{@configuration.built_app_path}/Info.plist")
         plist_data = CFPropertyList.native_types(plist.value)
         File.open("pkg/dist/manifest.plist", "w") do |io|
           io << %{

--- a/lib/beta_builder/deployment_strategies/web.rb
+++ b/lib/beta_builder/deployment_strategies/web.rb
@@ -21,65 +21,64 @@ module BetaBuilder
         plist = CFPropertyList::List.new(:file => "#{@configuration.built_app_path}/Info.plist")
         plist_data = CFPropertyList.native_types(plist.value)
         File.open("pkg/dist/manifest.plist", "w") do |io|
-          io << %{
-            <?xml version="1.0" encoding="UTF-8"?>
-            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-            <plist version="1.0">
-            <dict>
-              <key>items</key>
-              <array>
-                <dict>
-                  <key>assets</key>
-                  <array>
-                    <dict>
-                      <key>kind</key>
-                      <string>software-package</string>
-                      <key>url</key>
-                      <string>#{@configuration.deployment_url}</string>
-                    </dict>
-                  </array>
-                  <key>metadata</key>
-                  <dict>
-                    <key>bundle-identifier</key>
-                    <string>#{plist_data['CFBundleIdentifier']}</string>
-                    <key>bundle-version</key>
-                    <string>#{plist_data['CFBundleVersion']}</string>
-                    <key>kind</key>
-                    <string>software</string>
-                    <key>title</key>
-                    <string>#{plist_data['CFBundleDisplayName']}</string>
-                  </dict>
-                </dict>
-              </array>
-            </dict>
-            </plist>
-          }
+          io << %{<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>items</key>
+    <array>
+      <dict>
+        <key>assets</key>
+        <array>
+          <dict>
+            <key>kind</key>
+            <string>software-package</string>
+            <key>url</key>
+            <string>#{@configuration.deployment_url}</string>
+          </dict>
+        </array>
+        <key>metadata</key>
+        <dict>
+          <key>bundle-identifier</key>
+          <string>#{plist_data['CFBundleIdentifier']}</string>
+          <key>bundle-version</key>
+          <string>#{plist_data['CFBundleVersion']}</string>
+          <key>kind</key>
+          <string>software</string>
+          <key>title</key>
+          <string>#{plist_data['CFBundleDisplayName']}</string>
+        </dict>
+      </dict>
+    </array>
+  </dict>
+</plist>
+}
         end
         File.open("pkg/dist/index.html", "w") do |io|
-          io << %{
-            <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-            <html xmlns="http://www.w3.org/1999/xhtml">
-            <head>
-            <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-            <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
-            <title>Beta Download</title>
-            <style type="text/css">
-            body {background:#fff;margin:0;padding:0;font-family:arial,helvetica,sans-serif;text-align:center;padding:10px;color:#333;font-size:16px;}
-            #container {width:300px;margin:0 auto;}
-            h1 {margin:0;padding:0;font-size:14px;}
-            p {font-size:13px;}
-            .link {background:#ecf5ff;border-top:1px solid #fff;border:1px solid #dfebf8;margin-top:.5em;padding:.3em;}
-            .link a {text-decoration:none;font-size:15px;display:block;color:#069;}
-            </style>
-            </head>
-            <body>
-            <div id="container">
-            <div class="link"><a href="itms-services://?action=download-manifest&url=#{@configuration.manifest_url}">Tap Here to Install<br />#{@configuration.target}<br />On Your Device</a></div>
-            <p><strong>Link didn't work?</strong><br />
-            Make sure you're visiting this page on your device, not your computer.</p>
-            </body>
-            </html>
-          }
+          io << %{<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"/>
+    <title>Beta Download</title>
+    <style type="text/css">
+      body {background:#fff;margin:0;padding:0;font-family:arial,helvetica,sans-serif;text-align:center;padding:10px;color:#333;font-size:16px;}
+      #container {width:300px;margin:0 auto;}
+      h1 {margin:0;padding:0;font-size:14px;}
+      p {font-size:13px;}
+      .link {background:#ecf5ff;border-top:1px solid #fff;border:1px solid #dfebf8;margin-top:.5em;padding:.3em;}
+      .link a {text-decoration:none;font-size:15px;display:block;color:#069;}
+    </style>
+  </head>
+  <body>
+    <div id="container">
+      <div class="link"><a href="itms-services://?action=download-manifest&url=#{@configuration.manifest_url}">Tap Here to Install<br />#{@configuration.target}<br />On Your Device</a></div>
+      <p><strong>Link didn't work?</strong><br />
+	Make sure you're visiting this page on your device, not your computer.</p>
+    </div>
+  </body>
+</html>
+}
         end
       end
       

--- a/lib/betabuilder.rb
+++ b/lib/betabuilder.rb
@@ -1,1 +1,1 @@
-require 'beta_builder'
+require File.dirname(__FILE__) + '/beta_builder'


### PR DESCRIPTION
Includes Pulls [Number 27](https://github.com/lukeredpath/betabuilder/pull/27), [Number 28](https://github.com/lukeredpath/betabuilder/pull/28), [Number 31](https://github.com/lukeredpath/betabuilder/pull/31), [Number 36](https://github.com/lukeredpath/betabuilder/pull/36), [Number 40](https://github.com/lukeredpath/betabuilder/pull/40)

Fixes IPA generation by using Apple's PackageApplication tool to sign the app and embed the mobile certificate, otherwise Testflight won't accept the build. (Pull 28)

Adds the ability to use git describe to set build variables that can be used to automate version numbers.

Adds the ability to set the destination path for the generated IPA. (defaults to the project directory)

Adds the ability to add command line args to `xcodebuild`

Adds support for setting the SCP port

Usings relative paths instead of Gem paths

Detect build failures and raise an exception

Adding full paths to xcodebuild and xcrun; they are override-able in the config

Adding ability to add arguments to package command

Changing argument / command structure

Making build and signing output optional (use config.verbose to trigger) 

Adding simplified output
