### PR TITLE
Upload dSYM to Testflight

### DIFF
--- a/lib/beta_builder.rb
+++ b/lib/beta_builder.rb
@@ -89,8 +89,16 @@ module BetaBuilder
         output.build_output_dir  
       end
       
+      def dsym_file_name
+        "#{app_file_name}.dSYM"
+      end
+
       def built_app_dsym_path
         "#{built_app_path}.dSYM"
+      end
+      
+      def built_app_dsym_zip_path
+        "#{built_app_dsym_path}.zip"
       end
       
       def dist_path


### PR DESCRIPTION
This will zip and upload the dSYM file during a Testflight deployment. This means Testflight can symbolicate crash reports, which is pretty handy. I couldn't think of a case when one _wouldn't_ want to do this, so I just made it the default behavior.
